### PR TITLE
fix: segmentation fault for error in update

### DIFF
--- a/internal/provider/resource_domain.go
+++ b/internal/provider/resource_domain.go
@@ -229,6 +229,7 @@ func (rs *DomainResource) Update(ctx context.Context, req resource.UpdateRequest
 			"API Error Updating Domain",
 			"Could not update domain with ID "+plan.Id.ValueString()+": "+err.Error(),
 		)
+		return
 	}
 
 	data, diags := mapDomainValuesToType(ctx, domain)

--- a/internal/provider/resource_org.go
+++ b/internal/provider/resource_org.go
@@ -216,6 +216,7 @@ func (r *orgResource) Update(ctx context.Context, req resource.UpdateRequest, re
 			"Unable to update Org",
 			"Could not update org with ID "+plan.ID.ValueString()+" and name "+plan.Name.ValueString()+": "+err.Error(),
 		)
+		return
 	}
 
 	plan, diags = mapOrgValuesToType(ctx, org)

--- a/internal/provider/resource_route.go
+++ b/internal/provider/resource_route.go
@@ -301,6 +301,7 @@ func (rs *RouteResource) Update(ctx context.Context, req resource.UpdateRequest,
 			"API Error Updating Route",
 			"Could not update Route with ID "+plan.Id.ValueString()+" : "+err.Error(),
 		)
+		return
 	}
 
 	data, diags := mapRouteValuesToType(ctx, route)

--- a/internal/provider/resource_security_group.go
+++ b/internal/provider/resource_security_group.go
@@ -269,6 +269,7 @@ func (rs *SecurityGroupResource) Update(ctx context.Context, req resource.Update
 			"API Error Updating Security Group",
 			"Could not update Security Group with ID "+plan.Id.ValueString()+" : "+err.Error(),
 		)
+		return
 	}
 
 	data, diags := mapSecurityGroupValuesToType(ctx, securityGroup)

--- a/internal/provider/resource_space_quota.go
+++ b/internal/provider/resource_space_quota.go
@@ -242,6 +242,7 @@ func (r *spaceQuotaResource) Update(ctx context.Context, req resource.UpdateRequ
 			"Unable to update space quota",
 			fmt.Sprintf("Request failed with %s", err.Error()),
 		)
+		return
 	}
 	spacesQuotaType, diags := mapSpaceQuotaValuesToType(spacesQuotaResp)
 	resp.Diagnostics.Append(diags...)


### PR DESCRIPTION
Was getting the below error if error occured while update

```
╷
│ Error: Plugin did not respond
│ 
│ The plugin encountered an error, and failed to respond to the plugin6.(*GRPCProvider).ApplyResourceChange call. The plugin logs may contain more details.
╵

Stack trace from the terraform-provider-cloudfoundry plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x8ef3ed3]
```

The proposed code changes seem to fix it.