### PR TITLE
fix: Allows module creation involving service instance

### DIFF
--- a/internal/provider/resource_service_instance.go
+++ b/internal/provider/resource_service_instance.go
@@ -192,7 +192,7 @@ func (r *serviceInstanceResource) ValidateConfig(ctx context.Context, req resour
 	}
 
 	// If Service Instance is of type managed only parameters is allowed to pass
-	if !config.Parameters.IsNull() && config.Type.ValueString() != "managed" {
+	if !config.Parameters.IsNull() && config.Type.ValueString() == userProvidedServiceInstance {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("type"),
 			"Parameters can only passed to service instance of type managed",
@@ -203,7 +203,7 @@ func (r *serviceInstanceResource) ValidateConfig(ctx context.Context, req resour
 
 	// If Service instance of type user-provided then credentials , syslog_drain_url and route_service_url allowed
 	if !config.SyslogDrainURL.IsNull() || !config.RouteServiceURL.IsNull() || !config.Credentials.IsNull() {
-		if config.Type.ValueString() != "user-provided" {
+		if config.Type.ValueString() == managedSerivceInstance {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("type"),
 				"Mistmatch attribute passed to user provided service instance",
@@ -211,7 +211,6 @@ func (r *serviceInstanceResource) ValidateConfig(ctx context.Context, req resour
 			)
 		}
 	}
-
 }
 
 func (r *serviceInstanceResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
- Allows service instance to be created as a module as previous validation was breaking it giving errors like this 
```t
│ Error: Parameters can only passed to service instance of type managed
│ 
│   with module.create_cf_service_instance_ems.cloudfoundry_service_instance.service,
│   on ../../modules/btp-cf/serviceinstance_btp_cf/serviceinstance_btp_cf.tf line 27, in resource "cloudfoundry_service_instance" "service":
│   27:   type         = var.type
│ 
│ Parameters json object can only be passed to managed serivce instance
```

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No


## Pull Request Type

What kind of change does this Pull Request introduce?
<!-- Please check the one that applies to this PR using "X". -->

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## How to Test

- Test the code via automated test

```bash
go test ./...
```

<!-- Add additional steps if applicable -->
- Additional test steps

```
...
```

## What to Check

Verify that the following are valid:

- Automated tests are executed successfully
<!-- Add additional conditions if applicable -->
- ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->

## Checklist for reviewer

<!-- This checklist needs to completed by the reviewer of the PR -->
The following organizational tasks must be completed before merging this PR:

- [ ] The PR is assigned to the Terraform project and a status is set (typically "in review").
- [ ] The PR has the matching labels assigned to it.
- [ ] The PR has a milestone assigned to it.
- [ ] If the PR closes an issue, the issue is referenced.
- [ ] Possible follow-up items are created and linked.
